### PR TITLE
#182210047 fixes identification and redirection in socialauth controller

### DIFF
--- a/src/controllers/socialAuth.js
+++ b/src/controllers/socialAuth.js
@@ -13,6 +13,7 @@ class Social {
     let userGot;
     let google = null;
     let facebook = null;
+    let userEmail;
     const column = `${req.user.provider}`;
     if (column === 'google') {
       google = req.user.id; 
@@ -25,12 +26,17 @@ class Social {
     const facebookSearch = await userService.findByProp({
       facebookId: req.user.id,
     });
-    if(req.user.emails.length == 0) {
-      return errorResponse(res, 403, `cannot login. the user's ${req.user.provider} account has no assigned email.`);
+    const userDetails = req.user;
+    let exist = [];
+    if(!(Object.keys(userDetails).includes("emails"))) {
+      userEmail=req.user.id + "@fake_" +req.user.provider+".com";
     }
-    const exist = await userService.findByProp({
-      email: req.user.emails[0].value,
-    });
+    else{
+      exist = await userService.findByProp({
+        email: req.user.emails[0].value,
+      });
+      userEmail = req.user.emails[0].value;
+    }
     if (googleSearch[0] || facebookSearch[0]) {
       if (!googleSearch[0]) {
         userGot = facebookSearch[0].dataValues;
@@ -48,9 +54,9 @@ class Social {
       const newUser = {
         firstName: req.user.name.familyName,
         lastName: req.user.name.givenName,
-        email: req.user.emails[0].value,
+        email: userEmail,
         password: Math.random().toString(),
-        isVerified: req.user.emails[0].verified,
+        isVerified: true,
         googleId: google,
         facebookId: facebook,
       };
@@ -74,7 +80,7 @@ class Social {
       loginIp: req.ip,
       lastSessionTime: new Date(),
     });
-    return successResponse(res, status, Action, token);
+    res.redirect('https://nomad-travelers-winners.herokuapp.com/?token='+token);
     
   }
 }


### PR DESCRIPTION
[Fixes #182210047]

#### What does this PR do?
It fixes the socialAuth controller to allow facebook accounts without assigned emails to login. It also allows redirection (after a successful login) to `https://nomad-travelers-winners.herokuapp.com/?token=[TOKEN]` (which is the production website of the front-end), where `[TOKEN]` is the authentication token for the logged in user.

#### Description of Task to be completed?
- fix problems of identification for facebook accounts that has not assigned emails
- add redirection response for successful login.
    
#### How should this be manually tested?
- clone this repository
- set up `.env` file as shown in `.env.example` and run `npm install`
- login using your google account at this link: `localhost:5000/api/oauth/google/`
- the result will be a redirection to `https://nomad-travelers-winners.herokuapp.com/?token=[TOKEN]` (which is the production website of the front-end), where `[TOKEN]` is the authentication token for the logged in user.

#### Any background context you want to provide?
- when logged in using facebook account without an assigned email, for the first time the controller will generate a fake email address as a string to register in the user table (database).
- the redirecting link contains token, which may cause security problems for non HTTPS protocols.
#### What are the relevant pivotal tracker stories?
#182210047
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A